### PR TITLE
Track app entry point and main function name

### DIFF
--- a/src/covid_shared/cli_tools.py
+++ b/src/covid_shared/cli_tools.py
@@ -163,6 +163,7 @@ def pass_run_metadata(run_metadata=RunMetadata()):
         @functools.wraps(app_entry_point)
         def _wrapped(*args, **kwargs):
             # Record arguments for the run and inject the metadata.
+            run_metadata['tool_name'] = f'{app_entry_point.__module__}:{app_entry_point.__name__}'
             run_metadata['run_arguments'] = get_function_full_argument_mapping(app_entry_point,
                                                                                run_metadata, *args, **kwargs)
             return app_entry_point(run_metadata, *args, **kwargs)
@@ -198,6 +199,7 @@ def monitor_application(func: types.FunctionType, logger_: Any, with_debugger: b
         result = None
         try:
             # Record arguments for the run and inject the metadata
+            app_metadata['main_function'] = f'{func.__module__}:{func.__name__}'
             app_metadata['run_arguments'] = get_function_full_argument_mapping(func, app_metadata,
                                                                                *args, **kwargs)
             result = func(app_metadata, *args, **kwargs)


### PR DESCRIPTION
Snapshot example:
```
app_metadata:
  main_function: covid_input_snapshot.cli.make_snapshot:make_snapshot
  run_arguments:
    mark_as_best: 'False'
    output_metadata: Metadata
    snapshot_directory: /ihme/covid-19/snapshot-data/2020_04_16.2
output_path: /ihme/covid-19/snapshot-data/2020_04_16.2
run_arguments:
  mark_dir_as_best: 'False'
  run_metadata: RunMetadata
  snapshot_root: /ihme/covid-19/snapshot-data
  verbose: '2'
  with_debugger: 'True'
run_time: 649.30 seconds
start_time: '2020_04_16_15_43_10'
tool_name: covid_input_snapshot.cli.cli:snapshot
```