### PR TITLE
add file-based logging

### DIFF
--- a/src/covid_shared/cli_tools.py
+++ b/src/covid_shared/cli_tools.py
@@ -20,7 +20,7 @@ from covid_shared.shell_tools import mkdir
 
 DEFAULT_LOG_MESSAGING_FORMAT = ('<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | '
                                 '<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> '
-                                '- <level>{message}</level>')
+                                '- <level>{message}</level> - {extra}')
 
 LOG_FORMATS = {
     # Keys are verbosity.  Specify special log formats here.
@@ -30,7 +30,7 @@ LOG_FORMATS = {
 }
 
 
-def add_logging_sink(sink: typing.TextIO, verbose: int, colorize: bool = False, serialize: bool = False):
+def add_logging_sink(sink: Union[typing.TextIO, Path], verbose: int, colorize: bool = False, serialize: bool = False):
     """Add a new output file handle for logging."""
     level, message_format = LOG_FORMATS.get(verbose, LOG_FORMATS[max(LOG_FORMATS.keys())])
     logger.add(sink, colorize=colorize, level=level, format=message_format, serialize=serialize)
@@ -40,6 +40,16 @@ def configure_logging_to_terminal(verbose: int):
     """Setup logging to sys.stdout."""
     logger.remove(0)  # Clear default configuration
     add_logging_sink(sys.stdout, verbose, colorize=True)
+
+
+def make_log_path(output_path: Path) -> None:
+    log_path = output_path / paths.LOG_DIR
+    mkdir(log_path, exists_ok=True)
+
+
+def configure_logging_to_files(output_path: Path) -> None:
+    add_logging_sink(output_path / paths.LOG_DIR / paths.DETAILED_LOG_FILE_NAME, verbose=2, serialize=True)
+    add_logging_sink(output_path / paths.LOG_DIR / paths.LOG_FILE_NAME, verbose=1)
 
 
 # Common click options

--- a/src/covid_shared/cli_tools.py
+++ b/src/covid_shared/cli_tools.py
@@ -42,12 +42,9 @@ def configure_logging_to_terminal(verbose: int):
     add_logging_sink(sys.stdout, verbose, colorize=True)
 
 
-def make_log_path(output_path: Path) -> None:
+def configure_logging_to_files(output_path: Path) -> None:
     log_path = output_path / paths.LOG_DIR
     mkdir(log_path, exists_ok=True)
-
-
-def configure_logging_to_files(output_path: Path) -> None:
     add_logging_sink(output_path / paths.LOG_DIR / paths.DETAILED_LOG_FILE_NAME, verbose=2, serialize=True)
     add_logging_sink(output_path / paths.LOG_DIR / paths.LOG_FILE_NAME, verbose=1)
 

--- a/src/covid_shared/paths.py
+++ b/src/covid_shared/paths.py
@@ -28,6 +28,10 @@ NY_TIMES_OUTPUT_DIR_NAME = 'ny_times_repo'
 MOBILITY_OUTPUT_DIR_NAME = 'mobility_data'
 ONEDRIVE_OUTPUT_DIR_NAME = 'covid_onedrive'
 
+LOG_DIR = "logs"
+LOG_FILE_NAME = "master_log.txt"
+DETAILED_LOG_FILE_NAME = "master_log.json"
+
 
 def latest_production_snapshot_path():
     return _latest_prod_path(SNAPSHOT_ROOT)


### PR DESCRIPTION
For some reason, the {extra} dict isn't showing up in the terminal logger but is showing up in both files. That was pretty confusing to me, but it doesn't seem like a huge deal since that is current behavior for terminal anyway

Terminal output: 
![Screen Shot 2020-04-26 at 11 55 51 AM](https://user-images.githubusercontent.com/2823611/80316831-f3a8a400-87b4-11ea-8e41-ac822e539fb6.png)

human readable file output:
![Screen Shot 2020-04-26 at 11 57 19 AM](https://user-images.githubusercontent.com/2823611/80316851-1dfa6180-87b5-11ea-8cec-1aedf18c7993.png)

machine readable output:
![Screen Shot 2020-04-26 at 11 57 56 AM](https://user-images.githubusercontent.com/2823611/80316860-32d6f500-87b5-11ea-9f60-0067e8e570bf.png)

