### PR TITLE
clean up get_last_stage_directory() to accept getting only one direct…

### DIFF
--- a/src/covid_shared/cli_tools.py
+++ b/src/covid_shared/cli_tools.py
@@ -10,6 +10,7 @@ import traceback
 import types
 import typing
 from typing import Any, Callable, Dict, Mapping, Optional, Union, Tuple
+from warnings import warn
 
 import click
 from loguru import logger
@@ -58,10 +59,6 @@ shared_options = [
     click.option('-v', 'verbose',
                  count=True,
                  help='Configure logging verbosity.'),
-    click.option('-e, --email-alert',
-                 type=bool,
-                 default=False,
-                 help='Send email when final job is done')
 ]
 
 
@@ -287,8 +284,24 @@ def get_run_directory(output_root: Union[str, Path]) -> Path:
 
 def get_last_stage_directory(last_stage_version: Union[str, Path], last_stage_directory: Union[str, Path] = None,
                              last_stage_root: Path = None) -> Path:
-    """Get the directory containing the results of the last pipeline stage."""
+    """Get the directory containing the results of the last pipeline stage.
+
+    Parameters
+    ----------
+    last_stage_version
+        The path to the version. Can either be an absolute path, or a path relative to the last_stage_root
+
+    last_stage_directory
+        Deprecated parameter. The path to the version. Should use last_stage_version instead
+
+    last_stage_root
+        The path to the root of the resource. Must be an absolute path.
+    """
+    if last_stage_directory:
+        warn(f'Usage of the "last_stage_directory" argument is deprecated. Please use "last_stage_version instead.',
+             Warning)
     last_stage_directory = last_stage_directory if last_stage_directory is not None else last_stage_version
+    # If last_stage_directory is an absolute path, the last_stage_root will be ignored here
     last_stage_directory = (last_stage_root / last_stage_directory if last_stage_root is not None
                             else last_stage_directory)
     if not last_stage_directory.is_absolute():

--- a/src/covid_shared/cli_tools.py
+++ b/src/covid_shared/cli_tools.py
@@ -285,15 +285,15 @@ def get_run_directory(output_root: Union[str, Path]) -> Path:
     return datetime_dir
 
 
-def get_last_stage_directory(last_stage_version: str, last_stage_directory: Union[str, Path],
+def get_last_stage_directory(last_stage_version: Union[str, Path], last_stage_directory: Union[str, Path] = None,
                              last_stage_root: Path = None) -> Path:
     """Get the directory containing the results of the last pipeline stage."""
-    if last_stage_directory:
-        return Path(last_stage_directory)
-    elif last_stage_root is None:
-        raise ValueError('No previous stage results found.')
-    else:
-        return last_stage_root / last_stage_version
+    last_stage_directory = last_stage_directory if last_stage_directory is not None else last_stage_version
+    last_stage_directory = (last_stage_root / last_stage_directory if last_stage_root is not None
+                            else last_stage_directory)
+    if not last_stage_directory.is_absolute():
+        raise ValueError(f'Invalid version path: {last_stage_directory}')
+    return last_stage_directory
 
 
 def setup_directory_structure(output_root: Union[str, Path], with_production: bool = False) -> None:

--- a/src/covid_shared/cli_tools.py
+++ b/src/covid_shared/cli_tools.py
@@ -58,6 +58,10 @@ shared_options = [
     click.option('-v', 'verbose',
                  count=True,
                  help='Configure logging verbosity.'),
+    click.option('-e, --email-alert',
+                 type=bool,
+                 default=False,
+                 help='Send email when final job is done')
 ]
 
 

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -8,6 +8,9 @@ import pytest
 from covid_shared import cli_tools, paths
 
 MOCK_DATETIME = datetime(2020, 4, 25, 17, 5, 55)
+ABSOLUTE_PATH_1 = Path('/absolute/path/one')
+ABSOLUTE_PATH_2 = Path('/absolute/path/two')
+RELATIVE_PATH = Path('some/relative/path')
 
 
 @pytest.fixture
@@ -225,3 +228,22 @@ def test_mark_production(run_dir_root: Path):
     assert link_path.is_dir()
     assert link_path.is_symlink()
     assert link_path.resolve() == run_dir
+
+
+@pytest.mark.parametrize(('last_stage_version', 'last_stage_directory', 'last_stage_root', 'result'),
+                         [(ABSOLUTE_PATH_1, ABSOLUTE_PATH_2, None, ABSOLUTE_PATH_2),
+                          (ABSOLUTE_PATH_1, ABSOLUTE_PATH_2, ABSOLUTE_PATH_1, ABSOLUTE_PATH_2),
+                          (ABSOLUTE_PATH_1, None, None, ABSOLUTE_PATH_1),
+                          (ABSOLUTE_PATH_1, None, ABSOLUTE_PATH_2, ABSOLUTE_PATH_1),
+                          (None, ABSOLUTE_PATH_1, None, ABSOLUTE_PATH_1),
+                          (ABSOLUTE_PATH_1, RELATIVE_PATH, None, None),
+                          (ABSOLUTE_PATH_1, RELATIVE_PATH, ABSOLUTE_PATH_2, ABSOLUTE_PATH_2 / RELATIVE_PATH),
+                          (RELATIVE_PATH, None, None, None),
+                          (RELATIVE_PATH, None, ABSOLUTE_PATH_1, ABSOLUTE_PATH_1 / RELATIVE_PATH),
+                          ])
+def test_get_last_stage_directory(last_stage_version, last_stage_directory, last_stage_root, result):
+    if result:
+        assert cli_tools.get_last_stage_directory(last_stage_version, last_stage_directory, last_stage_root) == result
+    else:
+        with pytest.raises(ValueError):
+            cli_tools.get_last_stage_directory(last_stage_version, last_stage_directory, last_stage_root)

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -236,14 +236,19 @@ def test_mark_production(run_dir_root: Path):
                           (ABSOLUTE_PATH_1, None, None, ABSOLUTE_PATH_1),
                           (ABSOLUTE_PATH_1, None, ABSOLUTE_PATH_2, ABSOLUTE_PATH_1),
                           (None, ABSOLUTE_PATH_1, None, ABSOLUTE_PATH_1),
-                          (ABSOLUTE_PATH_1, RELATIVE_PATH, None, None),
                           (ABSOLUTE_PATH_1, RELATIVE_PATH, ABSOLUTE_PATH_2, ABSOLUTE_PATH_2 / RELATIVE_PATH),
-                          (RELATIVE_PATH, None, None, None),
                           (RELATIVE_PATH, None, ABSOLUTE_PATH_1, ABSOLUTE_PATH_1 / RELATIVE_PATH),
                           ])
 def test_get_last_stage_directory(last_stage_version, last_stage_directory, last_stage_root, result):
-    if result:
-        assert cli_tools.get_last_stage_directory(last_stage_version, last_stage_directory, last_stage_root) == result
-    else:
-        with pytest.raises(ValueError):
-            cli_tools.get_last_stage_directory(last_stage_version, last_stage_directory, last_stage_root)
+    assert cli_tools.get_last_stage_directory(last_stage_version, last_stage_directory, last_stage_root) == result
+
+
+@pytest.mark.parametrize(('last_stage_version', 'last_stage_directory', 'last_stage_root'),
+                         [(ABSOLUTE_PATH_1, RELATIVE_PATH, None),
+                          (RELATIVE_PATH, None, None),
+                          (RELATIVE_PATH, None, RELATIVE_PATH),
+                          (RELATIVE_PATH, RELATIVE_PATH, RELATIVE_PATH)
+                          ])
+def test_get_last_stage_directory_errors(last_stage_version, last_stage_directory, last_stage_root):
+    with pytest.raises(ValueError):
+        cli_tools.get_last_stage_directory(last_stage_version, last_stage_directory, last_stage_root)


### PR DESCRIPTION
This should make it so that we don't need to send two types of options to our clis, one expecting best/latest and the other a path. This way it will take either an absolute path or a relative path to the root provided. If we don't want to provide both options we can omit `last_stage_directory`