### PR TITLE
create generic update method for metadata files

### DIFF
--- a/src/covid_shared/cli_tools.py
+++ b/src/covid_shared/cli_tools.py
@@ -143,15 +143,13 @@ class RunMetadata(Metadata, YamlIOMixin):
         super().__init__(*args, **kwargs)
         self['start_time'] = datetime.datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
 
-    def update(self, metadata_update: Mapping):
-        """Dictionary style update of metadata. If a value to store is the path to a metadata file, store that file's
-         contents instead."""
-        for key, value in metadata_update.items():
-            if type(value) == Path and value.name == paths.METADATA_FILE_NAME:
-                with value.open() as metadata_file:
-                    self.update_from_file(key, metadata_file)
-            else:
-                self[key] = value
+    def update_from_path(self, metadata_key: str, metadata_path: Union[str, Path]):
+        """Updates metadata from a metadata file path."""
+        metadata_path = Path(metadata_path)
+        if not metadata_path.name == paths.METADATA_FILE_NAME:
+            raise ValueError('Can only update from `metadata.yaml` files.')
+        with metadata_path.open() as metadata_file:
+            self.update_from_file(metadata_key, metadata_file)
 
     def update_from_file(self, metadata_key: str, metadata_file: typing.TextIO):
         """Loads a metadata file from disk and stores it in the key."""

--- a/src/covid_shared/paths.py
+++ b/src/covid_shared/paths.py
@@ -26,21 +26,21 @@ SEIR_COVARIATES_OUTPUT_ROOT = Path('/ihme/covid-19/seir-covariates')
 
 
 # Shared file names
-METADATA_FILE_NAME = 'metadata.yaml'
-BEST_LINK = 'best'
-LATEST_LINK = 'latest'
-PRODUCTION_RUN = 'production-runs'
+METADATA_FILE_NAME = Path('metadata.yaml')
+BEST_LINK = Path('best')
+LATEST_LINK = Path('latest')
+PRODUCTION_RUN = Path('production-runs')
 
-JOHNS_HOPKINS_OUTPUT_DIR_NAME = 'johns_hopkins_repo'
-ITALY_OUTPUT_DIR_NAME = 'italy_repo'
-NY_TIMES_OUTPUT_DIR_NAME = 'ny_times_repo'
-NOAA_OUTPUT_DIR_NAME = 'noaa_data'
-MOBILITY_OUTPUT_DIR_NAME = 'mobility_data'
-ONEDRIVE_OUTPUT_DIR_NAME = 'covid_onedrive'
+JOHNS_HOPKINS_OUTPUT_DIR_NAME = Path('johns_hopkins_repo')
+ITALY_OUTPUT_DIR_NAME = Path('italy_repo')
+NY_TIMES_OUTPUT_DIR_NAME = Path('ny_times_repo')
+NOAA_OUTPUT_DIR_NAME = Path('noaa_data')
+MOBILITY_OUTPUT_DIR_NAME = Path('mobility_data')
+ONEDRIVE_OUTPUT_DIR_NAME = Path('covid_onedrive')
 
-LOG_DIR = "logs"
-LOG_FILE_NAME = "master_log.txt"
-DETAILED_LOG_FILE_NAME = "master_log.json"
+LOG_DIR = Path("logs")
+LOG_FILE_NAME = Path("master_log.txt")
+DETAILED_LOG_FILE_NAME = Path("master_log.json")
 
 
 def latest_production_snapshot_path():


### PR DESCRIPTION
Creating a method that can be used to update RunMetadata with either simple keys or a Path to an existing metadata file. Also defines existing path constants as Path objects.

We have no existing tests for Metadata functions. I can create them if that is something we think it a high priority.