### PR TITLE
added location metadata path

### DIFF
--- a/src/covid_shared/paths.py
+++ b/src/covid_shared/paths.py
@@ -25,6 +25,7 @@ MODEL_INPUTS_ROOT = Path('/ihme/covid-19/model-inputs/')
 
 DEATHS_SPLINE_OUTPUT_ROOT = Path('/ihme/covid-19/deaths-outputs/')
 INFECTIONATOR_OUTPUTS = Path('/ihme/covid-19/seir-inputs')
+LOCATION_METADATA_INPUTS = Path('/ihme/covid-19/seir-pipeline-outputs/metadata-inputs')
 
 MASK_USE_OUTPUT_ROOT = Path('/ihme/covid-19/mask-use-outputs')
 PNEUMONIA_OUTPUT_ROOT = Path('/ihme/covid-19/pneumonia')

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -252,3 +252,15 @@ def test_get_last_stage_directory(last_stage_version, last_stage_directory, last
 def test_get_last_stage_directory_errors(last_stage_version, last_stage_directory, last_stage_root):
     with pytest.raises(ValueError):
         cli_tools.get_last_stage_directory(last_stage_version, last_stage_directory, last_stage_root)
+
+
+def test_location_metadata_path():
+    """Testing the addition of a standardized location_set_path, the file format does not match
+     that of other versioned files (ex. INFECTIONATOR_OUTPUTS) so the 'version' includes the
+     full csv """
+    loc_set_path = cli_tools.get_last_stage_directory(
+        last_stage_version='location_metadata_677.csv',
+        last_stage_root=paths.LOCATION_METADATA_INPUTS)
+
+    assert loc_set_path == Path('/ihme/covid-19/seir-pipeline-outputs/metadata-inputs/'
+                                'location_metadata_677.csv')


### PR DESCRIPTION
added location metadata path to covid-shared to be used in seiir pipeline cli so that location hierarchy can be similarly standardized the way infectionator version are. I also added a test but can remove if you don't want it to be a part of production tests
![Screen Shot 2020-06-09 at 3 26 47 PM](https://user-images.githubusercontent.com/66643977/84207216-109bec80-aa6e-11ea-9600-9f855a05507f.png)
If this is not a change you think should be included or used by other stages in the covid pipeline I am happy to delete the PR
