### PR TITLE
Add serology paths

### DIFF
--- a/src/covid_shared/paths.py
+++ b/src/covid_shared/paths.py
@@ -12,6 +12,7 @@ NOAA_PM_DATA = "ftp://ftp.cdc.noaa.gov/Datasets/ncep.reanalysis.dailyavgs/surfac
 CITYMAPPER_MOBILITY_TEMPLATE = "https://cdn.citymapper.com/data/cmi/Citymapper_Mobility_Index_{DATE}.csv"
 OPEN_COVID19_GROUP_REPO = "https://github.com/beoutbreakprepared/nCoV2019/archive/master.zip"
 CDC_DEATHS_BY_RACE_ETHNICITY_AGE_STATE = "https://data.cdc.gov/api/views/ks3g-spdg/rows.csv?accessType=DOWNLOAD"
+SEROSURVEY_SUPPLEMENTAL_DATA = '/snfs1/Project/covid/data_intake/serology/supplemental_serosurvey_metadata'
 
 # Shared paths
 EXEC_R_SCRIPT_PATH = Path('/share/singularity-images/lbd/shells/singR.sh')
@@ -60,6 +61,8 @@ CDC_OUTPUT_DIR_NAME = Path('cdc_data')
 MOBILITY_OUTPUT_DIR_NAME = Path('mobility_data')
 ONEDRIVE_OUTPUT_DIR_NAME = Path('covid_onedrive')
 OPEN_COVID19_OUTPUT_DIR_NAME = Path('open_covid19_working_group')
+SEROSURVEY_OUTPUT_DIR_NAME = Path('serosurvey_data')
+SEROSURVEY_SUPPLEMENTAL_OUTPUT_DIR_NAME = Path('supplemental_serosurvey_metadata')
 
 LOG_DIR = Path("logs")
 LOG_FILE_NAME = Path("master_log.txt")


### PR DESCRIPTION
This adds a data path to copy from '/home/j/Project/covid/data_intake/serology/supplemental_serosurvey_metadata/' to save to '/serosurvey_data/supplemental_serosurvey_metadata/'.