### PR TITLE
define new public function for cleaning up after application monitoring

### DIFF
--- a/src/covid_shared/cli_tools/__init__.py
+++ b/src/covid_shared/cli_tools/__init__.py
@@ -11,3 +11,4 @@ from covid_shared.cli_tools.run_directory import (get_last_stage_directory, get_
                                                   mark_best_explicit, mark_explicit, mark_latest, mark_latest_explicit,
                                                   mark_production, mark_production_explicit, move_link,
                                                   setup_directory_structure)
+from covid_shared.cli_tools.cleanup import finish_application

--- a/src/covid_shared/cli_tools/cleanup.py
+++ b/src/covid_shared/cli_tools/cleanup.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+from typing import Optional
+
+from covid_shared.cli_tools.metadata import Metadata, RunMetadata
+from covid_shared.cli_tools.run_directory import make_links
+
+
+def finish_application(
+    run_metadata: RunMetadata,
+    app_metadata: Metadata,
+    run_directory: Path,
+    mark_as_best: bool,
+    production_tag: Optional[str]
+) -> None:
+    """
+    Every cli tool should do the following:
+        1. serialize metadata to disk
+        2. update symlinks (if successful application)
+        3. raise exception (if not sucessful)
+
+    Parameters
+    ------------
+        run_metadata: metadata from cli invocation
+        app_metadata: metadata from application getting monitored
+        run_directory: output path of application
+        mark_as_best: whether to update 'best' symlink
+        production_tag: what string to tag prod run, if any
+    """
+    run_metadata['app_metadata'] = app_metadata.to_dict()
+    run_metadata.dump(run_directory / 'metadata.yaml')
+
+    # Configure latest or best symlink
+    make_links(app_metadata, run_directory, mark_as_best, production_tag)
+
+    _raise_if_exception(app_metadata)
+
+
+def _raise_if_exception(app_metadata: Metadata) -> None:
+    """
+    CLI tools should return a non-zero error code in the case of an error.
+    cli_tools.monitor_application catches exceptions so we need to look for
+    and raise any exception in the app metadata if it exists.
+
+    There are 3 cases:
+        1. no exception. In that case metadata contains success=True
+        2. user interrupt. In that case metadata contains success=False and
+            error_info='User interrupt.'
+        3. any other exception: metadata contains success=False and error_info
+            is a dictionary with keys 'exception_type', 'exception_value',
+            'exc_traceback'
+    """
+    if app_metadata['success']:
+        return
+
+    error_info = app_metadata['error_info']
+    user_interrupt = 'interrupt' in error_info
+    if user_interrupt:
+        raise KeyboardInterrupt
+    else:
+        raise error_info['exception_value']

--- a/src/covid_shared/cli_tools/metadata.py
+++ b/src/covid_shared/cli_tools/metadata.py
@@ -8,7 +8,7 @@ import time
 import traceback
 import types
 import typing
-from typing import Any, Callable, Dict, Mapping, Union
+from typing import Any, Callable, Dict, Mapping, Optional, Union
 
 import click
 from loguru import logger
@@ -114,7 +114,7 @@ class RunMetadata(Metadata, YamlIOMixin):
 
 
 def monitor_application(func: types.FunctionType, logger_: Any, with_debugger: bool,
-                        app_metadata: Metadata = Metadata()) -> Callable:
+                        app_metadata: Optional[Metadata] = None) -> Callable:
     """Monitors an application for errors and injects a metadata container.
 
     Catches records them if they occur. Can also be configured to drop
@@ -133,7 +133,8 @@ def monitor_application(func: types.FunctionType, logger_: Any, with_debugger: b
         Record for application metadata.
 
     """
-
+    if app_metadata is None:
+        app_metadata = Metadata()
     @functools.wraps(func)
     def _wrapped(*args, **kwargs):
         result = None

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,0 +1,46 @@
+from loguru import logger
+import pytest
+
+from covid_shared.cli_tools import monitor_application
+from covid_shared.cli_tools.cleanup import _raise_if_exception
+
+
+def function_without_exception(app_metadata):
+    return
+
+
+def function_interrupted(app_metadata):
+    raise KeyboardInterrupt
+
+
+def function_custom_exception(app_metadata):
+    raise RuntimeError("custom error")
+
+
+def test_do_not_raise():
+    func = monitor_application(
+        func=function_without_exception,
+        logger_=logger,
+        with_debugger=False)
+    app_metadata, _result = func()
+    _raise_if_exception(app_metadata)
+
+
+def test_raise_interrupt():
+    func = monitor_application(
+        func=function_interrupted,
+        logger_=logger,
+        with_debugger=False)
+    app_metadata, _result = func()
+    with pytest.raises(KeyboardInterrupt):
+        _raise_if_exception(app_metadata)
+
+
+def test_raise_custom():
+    func = monitor_application(
+        func=function_custom_exception,
+        logger_=logger,
+        with_debugger=False)
+    app_metadata, _result = func()
+    with pytest.raises(RuntimeError, match='custom error'):
+        _raise_if_exception(app_metadata)


### PR DESCRIPTION
Nightly orchestration is running elastispliner even in the event of ETL failure because we do not return a non-zero exit code. This PR provides a new public function for clients to use after their application runs.