### PR TITLE
Prevent successful 'quick' runs from being marked 'latest'

### DIFF
--- a/src/covid_shared/cli_tools/cleanup.py
+++ b/src/covid_shared/cli_tools/cleanup.py
@@ -11,7 +11,7 @@ def finish_application(
     run_directory: Path,
     mark_as_best: bool,
     production_tag: Optional[str],
-    quick: int
+    quick: int = None
 ) -> None:
     """
     Every cli tool should do the following:

--- a/src/covid_shared/cli_tools/cleanup.py
+++ b/src/covid_shared/cli_tools/cleanup.py
@@ -10,7 +10,8 @@ def finish_application(
     app_metadata: Metadata,
     run_directory: Path,
     mark_as_best: bool,
-    production_tag: Optional[str]
+    production_tag: Optional[str],
+    quick: int
 ) -> None:
     """
     Every cli tool should do the following:
@@ -30,7 +31,7 @@ def finish_application(
     run_metadata.dump(run_directory / 'metadata.yaml')
 
     # Configure latest or best symlink
-    make_links(app_metadata, run_directory, mark_as_best, production_tag)
+    make_links(app_metadata, run_directory, mark_as_best, production_tag, quick)
 
     _raise_if_exception(app_metadata)
 

--- a/src/covid_shared/cli_tools/run_directory.py
+++ b/src/covid_shared/cli_tools/run_directory.py
@@ -88,7 +88,7 @@ def setup_directory_structure(output_root: Union[str, Path], with_production: bo
 
 
 def make_links(app_metadata: Metadata, run_directory: Path,
-               mark_as_best: bool, production_tag: Optional[str], quick: int) -> None:
+               mark_as_best: bool, production_tag: Optional[str], quick: Optional[int] = None) -> None:
     if app_metadata['success'] and not quick:
         mark_latest(run_directory)
 

--- a/src/covid_shared/cli_tools/run_directory.py
+++ b/src/covid_shared/cli_tools/run_directory.py
@@ -88,20 +88,19 @@ def setup_directory_structure(output_root: Union[str, Path], with_production: bo
 
 
 def make_links(app_metadata: Metadata, run_directory: Path,
-               mark_as_best: bool, production_tag: Optional[str], quick: int) -> None:
-    if app_metadata['success']:
-        if not quick:
-            mark_latest(run_directory)
+               mark_as_best: bool, production_tag: Optional[str], quick: int = None) -> None:
+    if app_metadata['success'] and not quick:
+        mark_latest(run_directory)
 
-            if mark_as_best:
-                mark_best(run_directory)
+        if mark_as_best:
+            mark_best(run_directory)
 
-                if production_tag:
-                    try:
-                        mark_production(run_directory, production_tag)
-                    except ValueError:
-                        logger.warning(f'Invalid production tag {production_tag}. Run not marked for production.'
-                                    f'Please provide production tag in format YYYY_MM_DD.')
+            if production_tag:
+                try:
+                    mark_production(run_directory, production_tag)
+                except ValueError:
+                    logger.warning(f'Invalid production tag {production_tag}. Run not marked for production.'
+                                f'Please provide production tag in format YYYY_MM_DD.')
 
 
 def mark_best(run_directory: Union[str, Path]) -> None:

--- a/src/covid_shared/cli_tools/run_directory.py
+++ b/src/covid_shared/cli_tools/run_directory.py
@@ -88,7 +88,7 @@ def setup_directory_structure(output_root: Union[str, Path], with_production: bo
 
 
 def make_links(app_metadata: Metadata, run_directory: Path,
-               mark_as_best: bool, production_tag: Optional[str], quick: int = None) -> None:
+               mark_as_best: bool, production_tag: Optional[str], quick: int) -> None:
     if app_metadata['success'] and not quick:
         mark_latest(run_directory)
 

--- a/src/covid_shared/cli_tools/run_directory.py
+++ b/src/covid_shared/cli_tools/run_directory.py
@@ -88,19 +88,20 @@ def setup_directory_structure(output_root: Union[str, Path], with_production: bo
 
 
 def make_links(app_metadata: Metadata, run_directory: Path,
-               mark_as_best: bool, production_tag: Optional[str]) -> None:
+               mark_as_best: bool, production_tag: Optional[str], quick: int) -> None:
     if app_metadata['success']:
-        mark_latest(run_directory)
+        if not quick:
+            mark_latest(run_directory)
 
-        if mark_as_best:
-            mark_best(run_directory)
+            if mark_as_best:
+                mark_best(run_directory)
 
-            if production_tag:
-                try:
-                    mark_production(run_directory, production_tag)
-                except ValueError:
-                    logger.warning(f'Invalid production tag {production_tag}. Run not marked for production.'
-                                   f'Please provide production tag in format YYYY_MM_DD.')
+                if production_tag:
+                    try:
+                        mark_production(run_directory, production_tag)
+                    except ValueError:
+                        logger.warning(f'Invalid production tag {production_tag}. Run not marked for production.'
+                                    f'Please provide production tag in format YYYY_MM_DD.')
 
 
 def mark_best(run_directory: Union[str, Path]) -> None:


### PR DESCRIPTION
We only want to mark full (ie not 'quick') snapshots and ETL runs as "latest"