### PR TITLE
Collijk/feature/make round trip invariant

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,9 @@ if __name__ == "__main__":
     install_requirements = [
         'loguru',
         'click',
-        'pyyaml'
+        'numpy',
+        'pandas',
+        'pyyaml',
     ]
 
     test_requirements = [

--- a/src/covid_shared/data_transformations.py
+++ b/src/covid_shared/data_transformations.py
@@ -1,0 +1,52 @@
+import pandas as pd
+
+
+def make_round_trip_invariant(cumulative_time_series: pd.Series) -> pd.Series:
+    """Drops nulls, interpolates, and adds a leading zero.
+
+    This function drops nulls from the cumulative time series, interpolates
+    missing days linearly, and then pads the front of the
+    series with a 0 so that the resulting series has the property:
+
+        s == s.groupby('location_id').diff().fillna(0).groupby('location_id').cumsum()
+
+    which is to say we can preserve the counts under conversions between daily
+    and cumulative space.
+
+    Parameters
+    ----------
+    cumulative_time_series
+        A series with indexed by location id and date.
+
+    Returns
+    -------
+    pd.Series
+        A series with interior null values interpolated and with a leading
+        zero such that transforming to daily and back to cumulative is
+        an invariant transformation.
+
+    """
+    name = cumulative_time_series.name if cumulative_time_series.name else 'value'
+    cumulative_time_series = cumulative_time_series.rename(name)
+
+    data = cumulative_time_series.dropna()
+
+    non_zero_data = data.loc[data != 0.]
+    min_date = non_zero_data.reset_index().groupby('location_id').date.min()
+    prepend_date = min_date - pd.Timedelta(days=1)
+    prepend_idx = prepend_date.reset_index().set_index(['location_id', 'date']).index
+    prepend_idx = prepend_idx.difference(data.index)
+    prepend = pd.Series(0., index=prepend_idx, name=name)
+    data = data.append(prepend).sort_index()
+
+    loc_ids = data.reset_index().location_id.unique()
+    final_series = []
+    for loc_id in loc_ids:
+        s = (data
+             .loc[loc_id]
+             .asfreq('D')
+             .interpolate()
+             .reset_index())
+        s['location_id'] = loc_id
+        final_series.append(s.set_index(['location_id', 'date'])[name])
+    return pd.concat(final_series).rename(cumulative_time_series.name).sort_index()

--- a/tests/test_data_transformations.py
+++ b/tests/test_data_transformations.py
@@ -1,0 +1,59 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from covid_shared.data_transformations import make_round_trip_invariant
+
+
+@pytest.fixture(scope='function')
+def time_series():
+    # 30 elements.  Linear ramp, flat, linear ramp.
+    time_series = np.hstack([
+        np.arange(1, 11),
+        11 * np.ones(10),
+        2 * np.arange(11, 21)
+    ])
+    dates = pd.date_range(start='2021-01-15', periods=time_series.size)
+    location_ids = [123, 456, 789, 987, 654, 321]
+    s = []
+    for location_id in location_ids:
+        idx = pd.MultiIndex.from_product([[location_id], dates], names=['location_id', 'date'])
+        s.append(pd.Series(time_series, index=idx))
+    return pd.concat(s)
+
+
+def invariant_transform(ts):
+    return ts.groupby('location_id').diff().fillna(0).groupby('location_id').cumsum()
+
+
+def test_make_round_trip_invariant_no_side_effect(time_series):
+    ts_copy = time_series.copy(deep=True)
+    new_ts = make_round_trip_invariant(time_series)
+    assert not new_ts.equals(time_series)
+    assert ts_copy.equals(time_series)
+
+
+def test_make_round_trip_invariant(time_series):
+    assert not time_series.equals(invariant_transform(time_series))
+    new_ts = make_round_trip_invariant(time_series)
+    assert time_series.equals(new_ts.loc[time_series.index])
+    assert new_ts.equals(invariant_transform(new_ts))
+
+
+def test_make_round_trip_invariant_idempotent(time_series):
+    assert not time_series.equals(invariant_transform(time_series))
+    new_ts = make_round_trip_invariant(time_series)
+    new_ts2 = make_round_trip_invariant(new_ts)
+    assert new_ts.equals(new_ts2)
+
+
+@pytest.mark.parametrize('region', [0, 1, 2])
+def test_make_round_trip_invariant_interp(time_series, region):
+    def _drop_data_in_region(x):
+        x.iloc[10*region+3:10*region+8] = np.nan
+        return x
+
+    time_series_with_nulls = time_series.groupby('location_id').apply(_drop_data_in_region)
+    new_ts = make_round_trip_invariant(time_series_with_nulls)
+    assert time_series_with_nulls.dropna().equals(new_ts.loc[time_series_with_nulls.dropna().index])
+    assert new_ts.equals(invariant_transform(new_ts))


### PR DESCRIPTION
I was doing some code cleanup in SEIR and though this might be useful in ETL as well.  