### PR TITLE
remove validation module

### DIFF
--- a/src/covid_shared/cli_tools/__init__.py
+++ b/src/covid_shared/cli_tools/__init__.py
@@ -48,6 +48,3 @@ from covid_shared.cli_tools.run_directory import (
 from covid_shared.cli_tools.cleanup import (
     finish_application,
 )
-from covid_shared.cli_tools.validation import (
-    validate_options_with_q,
-)

--- a/src/covid_shared/cli_tools/validation.py
+++ b/src/covid_shared/cli_tools/validation.py
@@ -1,6 +1,0 @@
-def validate_options_with_q(quick: int, mark_best: bool, production_tag: str):
-    """
-    Quick runs should never be marked 'best' or for production
-    """
-    if quick and (mark_best or production_tag):
-        raise ValueError("Cannot mark a quick snapshot as best or for production.")


### PR DESCRIPTION
No one else uses this check so moving it into ETL

See related etl PR: https://stash.ihme.washington.edu/projects/CVD19/repos/covid-input-etl/pull-requests/800/overview